### PR TITLE
Configuration improvements

### DIFF
--- a/lib/chef/knife/cssh-summon.rb
+++ b/lib/chef/knife/cssh-summon.rb
@@ -17,6 +17,14 @@ module KnifeCssh
     return nil
   end
 
+  def self.find_command(*cmds)
+    cmd = self.which *cmds
+    return cmd if not cmd.nil?
+
+    puts "Unable to find any of the commands: #{cmds.join ', '} on PATH!"
+    exit 1
+  end
+
   class CsshSummon < Chef::Knife
 
     banner "knife cssh summon QUERY"
@@ -31,8 +39,8 @@ module KnifeCssh
       :short => '-c COMMAND',
       :long => '--cssh-command COMMAND',
       :description => 'Command to use instead of cssh/csshX',
-      :default => KnifeCssh::which('csshX', 'cssh'),
-      :proc => Proc.new { |cmd| KnifeCssh::which cmd }
+      :default => KnifeCssh::find_command('csshX', 'cssh'),
+      :proc => Proc.new { |cmd| KnifeCssh::find_command(cmd) }
 
     SPECIFIC_OPTIONS = {
       'tmux-cssh' => {

--- a/lib/chef/knife/cssh-summon.rb
+++ b/lib/chef/knife/cssh-summon.rb
@@ -33,7 +33,7 @@ module KnifeCssh
       :short => '-l USER',
       :long => '--login USER',
       :description => 'Username to use for login',
-      :default => 'root'
+      :default => ENV['USER']
 
     option :cssh_command,
       :short => '-c COMMAND',

--- a/lib/chef/knife/cssh-summon.rb
+++ b/lib/chef/knife/cssh-summon.rb
@@ -21,6 +21,12 @@ module KnifeCssh
 
     def run
       # this chef is mainly from chef own knife search command
+      if name_args.length < 1
+        puts 'Missing argument QUERY!'
+        show_usage
+        exit 1
+      end
+
       query = name_args[0]
       q = Chef::Search::Query.new
       escaped_query = URI.escape(query, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))

--- a/lib/chef/knife/cssh-summon.rb
+++ b/lib/chef/knife/cssh-summon.rb
@@ -5,11 +5,18 @@ module KnifeCssh
 
     banner "knife cssh summon QUERY"
 
+    option :login,
+      :short => '-l USER',
+      :long => '--login USER',
+      :description => 'Username to use for login',
+      :default => 'root'
+
     deps do
       require 'chef/node'
       require 'chef/environment'
       require 'chef/api_client'
       require 'chef/knife/search'
+      require 'shellwords'
     end
 
     def run
@@ -30,7 +37,7 @@ module KnifeCssh
         exit 1
       end
 
-      %x[cssh #{result_items.join(" ")}]
+      %x[cssh -l #{config[:login].shellescape} #{result_items.join(" ")}]
     end
 
     private

--- a/lib/chef/knife/cssh-summon.rb
+++ b/lib/chef/knife/cssh-summon.rb
@@ -21,8 +21,7 @@ module KnifeCssh
     cmd = self.which *cmds
     return cmd if not cmd.nil?
 
-    puts "Unable to find any of the commands: #{cmds.join ', '} on PATH!"
-    exit 1
+    nil
   end
 
   class CsshSummon < Chef::Knife
@@ -95,6 +94,11 @@ module KnifeCssh
     end
 
     def call_cssh(hosts)
+      if config[:cssh_command].nil?
+        puts "Unable to find any suitable cssh command on PATH!"
+        exit 1
+      end
+
       %x[#{config[:cssh_command]} #{get_impl_opt :user_switch} #{config[:login].shellescape} #{hosts.join(" ")}]
     end
 

--- a/lib/knife-cssh.rb
+++ b/lib/knife-cssh.rb
@@ -1,3 +1,3 @@
 module KnifeCssh
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
This changes makes `knife-cssh` more configurable by letting to set the user and the command to use.
#### Examples

Set the user used for ssh:

``` bash
knife cssh summon -l my-wonderful-user fqdn:*.example.com
```

Use a different implementation than cssh/csshX:

``` bash
knife cssh summon -c tmux-cssh name:web*
```
